### PR TITLE
fix: replace raw.githack.com URL with production URL (rawcdn.githack.com) in assets.ts

### DIFF
--- a/lib/data/assets.ts
+++ b/lib/data/assets.ts
@@ -1,7 +1,7 @@
 import fromEntries from "fromentries";
 import fetch from "node-fetch";
 
-const GhRawURL = "https://raw.githack.com";
+const GhRawURL = "https://rawcdn.githack.com";
 const GhApiURL = "https://api.github.com";
 
 const YearnAliasesURL = `${GhRawURL}/yearn/yearn-assets/master/icons/aliases.json`;


### PR DESCRIPTION
Use https://raw.githack.com/ production URLs until IPFS implementation. will reduce ~50 unnecessary redirects on vaults page