### PR TITLE
fix: updating token icons to production hostname rawcdn.githack.com

### DIFF
--- a/lib/data/assets.ts
+++ b/lib/data/assets.ts
@@ -1,7 +1,7 @@
 import fromEntries from "fromentries";
 import fetch from "node-fetch";
 
-const GhRawURL = "https://raw.githack.com";
+const GhRawURL = "https://rawcdn.githack.com";
 const GhApiURL = "https://api.github.com";
 
 const YearnAliasesURL = `${GhRawURL}/yearn/yearn-assets/master/icons/aliases.json`;


### PR DESCRIPTION
As per http://raw.githack.com/ instructions:

rawcdn.githack.com is the production hostname providing additional benefits (caching improvements, brotli compression of text based content, ending unnecessary 301 redirects slowing page loads)